### PR TITLE
updates to work with recent Spicy releases

### DIFF
--- a/analyzer/analyzer.spicy
+++ b/analyzer/analyzer.spicy
@@ -9,8 +9,8 @@ public type OSPFPacket = unit {
     checksum: uint16;
 
 	switch ( self.version ) {
-		2 -> ospfv2: OSPFPacketV2(self) &size=self.packet_length-14;
-		3 -> ospfv3: OSPFPacketV3(self) &size=self.packet_length-14;
+		2 -> ospfv2: OSPFPacketV2(self) &size=self.packet_length-14 &requires=(self.packet_length >= 24);
+		3 -> ospfv3: OSPFPacketV3(self) &size=self.packet_length-14 &requires=(self.packet_length >= 16);
         * -> payload: bytes &size=self.packet_length-14 if (self.packet_length-14 > 0);
 	};
 };
@@ -44,7 +44,7 @@ public type OSPFPacketV2 = unit(parent: OSPFPacket) {
     autype: uint16;
     auth: uint64;
 
-    var len: uint16 = parent.packet_length-24 &requires=(parent.packet_length >= 24);
+    var len: uint16 = parent.packet_length-24;
 
 	switch ( parent.ospf_type ) {
 		MsgType::Hello -> hello: HelloPacket(parent);
@@ -178,7 +178,7 @@ public type OSPFPacketV3 = unit(parent: OSPFPacket) {
     instance_id: uint8;
     : uint8;
 
-    var len: uint16 = parent.packet_length-16 &requires=(parent.packet_length >= 16);
+    var len: uint16 = parent.packet_length-16;
 
 	switch ( parent.ospf_type ) {
 		MsgType::Hello -> hello: HelloPacketV3(parent);

--- a/analyzer/main.zeek
+++ b/analyzer/main.zeek
@@ -155,8 +155,9 @@ const LinkTypes = {
 
 event zeek_init()
     {
-    if ( ! PacketAnalyzer::try_register_packet_analyzer_by_name("IP", 0x59, "spicy::OSPF") )
-		Reporter::error("cannot register OSPF Spicy analyzer");
+    if ( ! PacketAnalyzer::try_register_packet_analyzer_by_name("IP", 0x59, "spicy_OSPF") )
+        if ( ! PacketAnalyzer::try_register_packet_analyzer_by_name("IP", 0x59, "spicy::OSPF") )
+		    Reporter::error("cannot register OSPF Spicy analyzer");
     }
 
 event OSPF::hello(pkt: raw_pkt_hdr, version: count, router_id: addr, area_id: addr, netmask: addr, interface_id: count,

--- a/tests/analyzer/availability.zeek
+++ b/tests/analyzer/availability.zeek
@@ -1,3 +1,3 @@
-# @TEST-EXEC: zeek -NN | grep -qi ANALYZER_SPICY__OSPF
+# @TEST-EXEC: zeek -NN | grep -Pqi "(ANALYZER_SPICY__OSPF|ANALYZER_SPICY_OSPF)"
 #
 # @TEST-DOC: Check that the OSPF analyzer is available.


### PR DESCRIPTION
This PR contains a few minor changes to fix errors when trying to run with recent spicy versions:

1. Moved the `&requires` from the `OSPFPacketV2` and `OSPFPacketV3` units to the parent inside its `switch` statement, to address this error:

```
[error] /opt/zeek/var/lib/zkg/clones/package/zeek-spicy-ospf/analyzer/analyzer.spicy:47:5: attribute '&requires' not supported for unit variables
[error] /opt/zeek/var/lib/zkg/clones/package/zeek-spicy-ospf/analyzer/analyzer.spicy:181:5: attribute '&requires' not supported for unit variables
```

2. `try_register_packet_analyzer_by_name` now tries `spicy_OSPF` (which is what the current spicy wants, apparently), then tries the older `spicy::OSPF` before erroring out in `zeek_init`

3. changed the grep in the availability test to `grep -Pqi "(ANALYZER_SPICY__OSPF|ANALYZER_SPICY_OSPF)"` in order to check for both `ANALYZER_SPICY__OSPF` (old) and `ANALYZER_SPICY_OSPF` (new).

with these changes, for me at least, with Zeek v5.2.0 and spicy v1.42-74 I get the following on install:

```
> zkg install .
The following packages will be INSTALLED:
  /zeek-spicy-ospf (master)

Proceed? [Y/n] y
Running unit tests for "/zeek-spicy-ospf"
Installing "/zeek-spicy-ospf".............................................................
Installed "/zeek-spicy-osp
```